### PR TITLE
refactor: support dotted paths from the root

### DIFF
--- a/internal/formatter/formatter_test.go
+++ b/internal/formatter/formatter_test.go
@@ -102,7 +102,7 @@ func TestFormat(t *testing.T) {
 			},
 			indentUnit:   "\t",
 			outputWriter: nil,
-			wantOutput:   "[server]\n\tip = \"1.1.1.1\"\n\n\t[ports]\n\t\thttp = 80\n",
+			wantOutput:   "[server]\n\tip = \"1.1.1.1\"\n\n\t[server.ports]\n\t\thttp = 80\n",
 			wantErr:      false,
 		},
 		{

--- a/testtoml/README.md
+++ b/testtoml/README.md
@@ -1,0 +1,3 @@
+## What
+
+This directory has a few TOML files to test `go-pretty-toml`. It's not exhaustive, but useful.

--- a/testtoml/test1.toml
+++ b/testtoml/test1.toml
@@ -1,0 +1,19 @@
+configs = [
+  { Name = 'golangci-lint', FileName = '.golangci.yaml', Schemas = [
+    'v1.json',
+    'v2.json',
+  ] },
+  { Name = 'goreleaser', FileName = '.goreleaser.yaml', Schemas = [
+    'schema.json',
+    'pro.json',
+  ] },
+  { Name = 'pre-commit-config', FileName = '.pre-commit-config.yaml', Schemas = [
+    'pre-commit-config.json',
+  ] },
+  { Name = 'pyproject', FileName = 'pyproject.toml', Schemas = [
+    'pyproject.json',
+  ] },
+  { Name = 'prettierrc', FileName = '.prettierrc', Schemas = [
+    'prettierrc.json',
+  ] },
+]

--- a/testtoml/test2.toml
+++ b/testtoml/test2.toml
@@ -1,0 +1,34 @@
+[[configs]]
+  Name     = 'docker-compose'
+  FileName = 'docker-compose.yaml'
+  Schemas  = ['compose-spec.json']
+
+[[configs]]
+  Name     = 'golangci-lint'
+  FileName = '.golangci.yaml'
+  Schemas  = ['v1.json', 'v2.json']
+
+[[configs]]
+  Name     = 'goreleaser'
+  FileName = '.goreleaser.yaml'
+  Schemas  = ['pro.json', 'schema.json']
+
+[[configs]]
+  Name     = 'pre-commit-config'
+  FileName = '.pre-commit-config.yaml'
+  Schemas  = ['pre-commit-config.json']
+
+[[configs]]
+  Name     = 'pre-commit-hooks'
+  FileName = '.pre-commit-hooks.yaml'
+  Schemas  = ['pre-commit-hooks.json']
+
+[[configs]]
+  Name     = 'prettierrc'
+  FileName = '.prettierrc'
+  Schemas  = ['prettierrc.json']
+
+[[configs]]
+  Name     = 'pyproject'
+  FileName = 'pyproject.toml'
+  Schemas  = ['pyproject.json']

--- a/testtoml/test3.toml
+++ b/testtoml/test3.toml
@@ -1,0 +1,35 @@
+[databases]
+
+  [databases.db1]
+    Name = "db1.use1.example.com"
+    Port = 3306
+
+    [databases.db1.engine]
+      Name    = "MariaDB"
+      Version = "10.8"
+
+  [databases.db2]
+    Name = "db2.use1.example.com"
+    Port = 3306
+
+    [databases.db2.engine]
+      Name    = "MariaDB"
+      Version = "10.8"
+
+[servers]
+
+  [servers.foo]
+    Name = "foo.example.com"
+    Port = 80
+
+    [servers.foo.OperatingSystem]
+      Name    = "Ubuntu"
+      Version = "22.04"
+
+  [servers.web]
+    Name = "web.example.com"
+    Port = 443
+
+    [servers.web.OperatingSystem]
+      Name    = "Ubuntu"
+      Version = "20.04"


### PR DESCRIPTION
# Summary

_this summary is an experiment, courtesy of Gemini 2.5 Pro Preview_

Okay, here is the summary of changes formatted in Markdown:

## Summary of Changes in `internal/formatter/formatter.go`

Based on the provided diff, the key changes are focused on correctly formatting nested TOML tables using their full path names:

*   **Full Path Naming for Nested Tables**:
    *   The most significant change is how nested tables (both regular `[...]` and array tables `[[...]]`) are named in the formatted output.
    *   Previously, a nested table's header used only its local key (e.g., `` `[ports]` ``).
    *   **Now, it uses the full, dot-separated path from the root** (e.g., `` `[server.ports]` ``). This aligns with standard TOML conventions for representing nested structures.

*   **Path Tracking Added to Recursive Calls**:
    *   To enable full path naming, a new `currentPath []string` parameter was added to the recursive `formatMap` function and the helper functions `formatArrayTables` and `formatRegularTables`.
    *   This parameter keeps track of the hierarchy of keys leading to the current map being processed.

*   **Header Generation Logic Updated**:
    *   The `formatArrayTables` and `formatRegularTables` functions now use the `currentPath` along with the local key `k` to construct the `fullPathString`.
    *   This `fullPathString` is then used in the `[[...]]` or `[...]` header output (e.g., `fmt.Fprintf(output, "%s[%s]\n", currentIndent, fullPathString)`).
    *   The `currentIndent` string is still used solely for positioning the header line correctly.

*   **Improved Error Reporting**:
    *   Error messages generated within the formatting functions (e.g., when validating arrays or identifying tables) now include the `fullPathString`.
    *   This provides much clearer context about *where* in the nested TOML structure an error occurred.

*   **Simplified `formatSimpleKeys`**:
    *   The `formatSimpleKeys` helper function, which handles non-table key-value pairs, no longer requires path information.
    *   Its function signature was simplified by removing the unused `path` parameter.

*   **Minor Refinements**:
    *   Internal comments and function documentation were updated to reflect the new parameters and logic.
    *   The initial call to the recursive `formatMap` function within the main `Format` entry point now correctly starts with an empty `currentPath` (`[]string{}`).

In essence, the refactoring makes the formatter **aware of the nesting context**, allowing it to produce TOML output where nested table headers accurately reflect their position within the overall structure.
