### PR TITLE
fix: closing the file as one should

### DIFF
--- a/cmd/toml-fmt/main.go
+++ b/cmd/toml-fmt/main.go
@@ -115,6 +115,7 @@ func getInput(
 			err = fmt.Errorf("opening %s: %w", sourceName, err) // Wrap the error with context
 			return
 		}
+		defer file.Close() //nolint:errcheck
 		inputReader = file // Assign the opened file to the input reader
 	}
 	return // Return the determined reader, names, and nil error


### PR DESCRIPTION
I noticed while reviewing the code, that I didn't properly close the file. This does so.
