### PR TITLE
revert: "fix: closing the file as one should (#10)"

### DIFF
--- a/cmd/toml-fmt/main.go
+++ b/cmd/toml-fmt/main.go
@@ -115,7 +115,6 @@ func getInput(
 			err = fmt.Errorf("opening %s: %w", sourceName, err) // Wrap the error with context
 			return
 		}
-		defer file.Close() //nolint:errcheck
 		inputReader = file // Assign the opened file to the input reader
 	}
 	return // Return the determined reader, names, and nil error


### PR DESCRIPTION
This reverts commit 09d9d78cc7cbbd3ef329ccaa52dd313cf71cd724.

Encountered this:

```bash
toml-fmt .typos.toml   
Error: reading from file '.typos.toml': read .typos.toml: file already closed
```

Not sure why, but reverting for now.
